### PR TITLE
Info and script for changing log levels

### DIFF
--- a/for-you.md
+++ b/for-you.md
@@ -36,7 +36,7 @@ Start with the following: it is a DSC, repeat, it's a DSC. Meaning nothing you c
 
 1. All the *control loops* run in a sandbox-like environment (simple example using go panic/recover https://blog.golang.org/defer-panic-and-recover). Runtime panics are trapped and stack-trace logged to stdout/stderr.
 2. On Debian systems, systemd is used to start *control plane* as containers using various units. Use ``` sudo systemctl status <<UNIT>> ``` and ``` sudo journalctl ``` to get more information if your containers refused to start.
-3. Kubernetes uses glog library for logging. Make sure that you use correct the correct V ``` glog.V(<<LEVEL>>).XXXX ``` And make sure that you start your containers with the correct V parameters.  **acs-engine defaults to use --v=2** - change this to a higher value.
+3. Kubernetes uses glog library for logging. Make sure that you use correct the correct V ``` glog.V(<<LEVEL>>).XXXX ``` And make sure that you start your containers with the correct V parameters.  **acs-engine defaults to use --v=2** - change this to a higher value.  ([More information about changing log levels.](kube-log-levels.md))
 4. Use labels and selectors to place your pods on nodes you are already watching the logs for.
 5. Use docker logs to see what is happening 
 

--- a/kube-log-levels.md
+++ b/kube-log-levels.md
@@ -1,0 +1,37 @@
+# Changing Kubernetes log levels
+
+ACS Engine defaults to log level 2 (or 4 for apiserver).  When debugging it's often useful to change this to show more detail.  To do this:
+
+* `ssh` into the master VM
+  * E.g. `ssh -i .ssh/id_rsa azureuser@mycluster.westus.cloudapp.azure.com`
+* Change to the `/etc/kubernetes/manifests` directory.
+  * This will contain files named `kube-xyz.yaml` which are the config files for the various Kubernetes components, e.g. apiserver, controller-manager...
+* Edit the config file for each component where you want to see more detailed logs.
+  * The file will include a line of the form `- "--v=2"` (under `spec/containers/command`).
+  * Change the number to the desired log level.
+  * Save the file.
+* Once you save the file, kubelet will restart the relevant component with the new spec.
+
+## Helper script
+
+You can create a helper script to automate the process of ssh-ing in and editing the config file.  Here's an example.
+
+```
+#! /bin/bash
+
+if [ $# -ne 4 ]; then
+  echo "./loglevel.sh n cluster region {addon-manager|apiserver|controller-manager|scheduler}"
+  exit 1
+fi
+
+lvl=$1
+clus=$2
+rgn=$3
+role=$4
+
+ssh -i .ssh/id_rsa azureuser@${clus}.${rgn}.cloudapp.azure.com "sudo sed -i \"s|- \\\"--v=[0-9]\\+\\\"|- \\\"--v=${lvl}}\\\"|g\" /etc/kubernetes/manifests/kube-${role}.yaml"
+```
+
+(Note: replace the SSH key file with the one containing your own private key.)
+
+Example usage: `./loglevel.sh 5 mycluster australiasoutheast apiserver`


### PR DESCRIPTION
The FAQ advises increasing the log level from the ACS Engine default for dev/debugging purposes.  This PR incorporates the guidance from issue #1 (with steps spelled out in more detail for beginners like me!), and provides a script to quickly set the log level on any component on the master node.