### PR TITLE
Changed /mnt to /mount as mountpoint for the data disk

### DIFF
--- a/config-dev-machine.md
+++ b/config-dev-machine.md
@@ -42,8 +42,7 @@ lsblk
 
 # Create mount point (Don't use /mnt since it's the temporary storage on Azure VM)
 sudo mkdir -p /mount/d
-sudo chown $(whoami):$(whoami) /mount/d
-sudo chmod +rw /mount/d
+
 ou
 # Configure auto mount (modify /dev/sdc if your disk is not attached there)
 cat << EOF | sudo tee /etc/systemd/system/mount-d.mount
@@ -65,6 +64,9 @@ sudo systemctl enable mount-d.mount
 # manually start the mount point
 sudo systemctl start mount-d.mount
 
+# After mounting the disk, we need to change the owner:group of the directory:
+sudo chown $(whoami):$(whoami) /mount/d
+sudo chmod +rw /mount/d
 ```
 
 3. Install Docker & Build Essentials 

--- a/config-dev-machine.md
+++ b/config-dev-machine.md
@@ -123,7 +123,7 @@ sudo chmod g+rwx "/home/$USER/.docker" -R
 $(cd /tmp && wget https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz)
 sudo tar -C /usr/local -xzf /tmp/go1.8.3.linux-amd64.tar.gz
 echo "export PATH=$PATH:/usr/local/go/bin" | sudo tee --append /etc/profile
-echo "export PATH=$PATH:/usr/local/go/bin" | tee --append ~/.bashrc
+echo "export PATH=$PATH:~/go/bin" | tee --append ~/.bashrc
 source /etc/profile
 source ~/.bashrc
 ```

--- a/config-dev-machine.md
+++ b/config-dev-machine.md
@@ -93,6 +93,7 @@ EOF
 
 # Restart the service (allow docker sometime before starting again, do not trust systemd to do it)
 sudo systemctl daemon-reload
+
 sudo systemctl stop docker.service && sleep 3 && sudo systemctl start docker.service 
 ```
 
@@ -140,6 +141,7 @@ cd ~
 mkdir -p go/src/k8s.io/
 
 # clone it 
+cd ~/go/src/k8s.io
 git clone https://github.com/kubernetes/kubernetes.git
 
 # add your fork as a remote 

--- a/config-dev-machine.md
+++ b/config-dev-machine.md
@@ -44,7 +44,7 @@ lsblk
 sudo mkdir -p /mount/d
 sudo chown $(whoami):$(whoami) /mount/d
 sudo chmod +rw /mount/d
-
+ou
 # Configure auto mount (modify /dev/sdc if your disk is not attached there)
 cat << EOF | sudo tee /etc/systemd/system/mount-d.mount
 [Unit]
@@ -80,7 +80,7 @@ sudo apt-get install -y build-essential
 4. Configure Docker to use the data disk
 
 ```
-mkdir /mnt/d/docker-pwd
+mkdir /mount/d/docker-pwd
 sudo mkdir /etc/systemd/system/docker.service.d 
 
 cat << EOF | sudo tee /etc/systemd/system/docker.service.d/graph.conf

--- a/config-dev-machine.md
+++ b/config-dev-machine.md
@@ -1,3 +1,4 @@
+
 # Create Dev Machine
 
 1. Resource Group
@@ -39,19 +40,19 @@ lsblk
 # Format it
  sudo mkfs.ext4 /dev/sdc
 
-# Create mount point
-sudo mkdir /mnt/d
-sudo chown $(whoami):$(whoami) /mnt/d
-sudo chmod +rw /mnt/d
+# Create mount point (Don't use /mnt since it's the temporary storage on Azure VM)
+sudo mkdir -p /mount/d
+sudo chown $(whoami):$(whoami) /mount/d
+sudo chmod +rw /mount/d
 
 # Configure auto mount (modify /dev/sdc if your disk is not attached there)
-cat << EOF | sudo tee /etc/systemd/system/mnt-d.mount
+cat << EOF | sudo tee /etc/systemd/system/mount-d.mount
 [Unit]
 Description=Mount Data Disk
 
 [Mount]
 What=/dev/sdc
-Where=/mnt/d
+Where=/mount/d
 Type=ext4
 
 [Install]
@@ -59,10 +60,10 @@ WantedBy=multi-user.target
 EOF
 
 sudo systemctl daemon-reload
-sudo systemctl enable mnt-d.mount
+sudo systemctl enable mount-d.mount
 
 # manually start the mount point
-sudo systemctl start mnt-d.mount
+sudo systemctl start mount-d.mount
 
 ```
 
@@ -85,7 +86,7 @@ sudo mkdir /etc/systemd/system/docker.service.d
 cat << EOF | sudo tee /etc/systemd/system/docker.service.d/graph.conf
 [Service]
 ExecStart=
-ExecStart=/usr/bin/docker daemon -H fd:// --graph="/mnt/d/docker-pwd"
+ExecStart=/usr/bin/docker daemon -H fd:// --graph="/mount/d/docker-pwd"
 EOF
 
 # Restart the service (allow docker sometime before starting again, do not trust systemd to do it)

--- a/config-dev-machine.md
+++ b/config-dev-machine.md
@@ -97,7 +97,6 @@ sudo systemctl stop docker.service && sleep 3 && sudo systemctl start docker.ser
 ```
 
 5. Configure Docker Hub Login
-
 ```
 
 #Login to docker (follow the prompts)
@@ -124,7 +123,7 @@ sudo chmod g+rwx "/home/$USER/.docker" -R
 $(cd /tmp && wget https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz)
 sudo tar -C /usr/local -xzf /tmp/go1.8.3.linux-amd64.tar.gz
 echo "export PATH=$PATH:/usr/local/go/bin" | sudo tee --append /etc/profile
-echo "export PATH=$PATH:~/go/bin" | tee --append ~/.bashrc
+echo "export PATH=$PATH:/usr/local/go/bin" | tee --append ~/.bashrc
 source /etc/profile
 source ~/.bashrc
 ```


### PR DESCRIPTION
/mnt is a temporary storage in azure VM. So if we stop the VM, the mountpoint created under /mnt won't exist and the datadisk won't be mounted. Instead of using /mnt we can create /mount and then mount the data disk under /mount/d